### PR TITLE
feat: add endpoint to retrieve patient's TOTP qr-code

### DIFF
--- a/src/api/keycloak.ts
+++ b/src/api/keycloak.ts
@@ -73,16 +73,16 @@ export default abstract class KeycloakApi {
     return certsJson.keys.flatMap((key) => key.x5c);
   }
 
-  public static async setupTOTP(): Promise<string[]> {
-    const response = await fetch(`${this.baseUrl}/setup/totp`);
-
-    //TODO: handle different realms
+  public static async setupTOTP(patientId: string): Promise<string> {
+    const response = await fetch(
+      `${this.baseUrl}/${RealmsUtil.patientRealmName}/totp/setup/${patientId}`
+    );
 
     if (!response.ok)
       throw new Error(
         `Unable to fetch OTP setup from keycloak server. Server responded with HTTP ${response.status}.`
       );
 
-    return response.json;
+    return await response.text();
   }
 }

--- a/src/api/keycloak.ts
+++ b/src/api/keycloak.ts
@@ -73,10 +73,8 @@ export default abstract class KeycloakApi {
     return certsJson.keys.flatMap((key) => key.x5c);
   }
 
-  public static async setupTOTP(patientId: string): Promise<string> {
-    const response = await fetch(
-      `${this.baseUrl}/${RealmsUtil.patientRealmName}/totp/setup/${patientId}`
-    );
+  public static async setupTOTP(realm: RealmConfig, username: string): Promise<string> {
+    const response = await fetch(`${this.baseUrl}/${realm.realmName}/totp/setup/${username}`);
 
     if (!response.ok)
       throw new Error(

--- a/src/api/keycloak.ts
+++ b/src/api/keycloak.ts
@@ -72,4 +72,17 @@ export default abstract class KeycloakApi {
     const certsJson = (await response.json()) as KeycloakCerts;
     return certsJson.keys.flatMap((key) => key.x5c);
   }
+
+  public static async setupTOTP(): Promise<string[]> {
+    const response = await fetch(`${this.baseUrl}/setup/totp`);
+
+    //TODO: handle different realms
+
+    if (!response.ok)
+      throw new Error(
+        `Unable to fetch OTP setup from keycloak server. Server responded with HTTP ${response.status}.`
+      );
+
+    return response.json;
+  }
 }

--- a/src/express.ts
+++ b/src/express.ts
@@ -4,6 +4,7 @@ import cookieParser from "cookie-parser";
 import LoginRouter from "@/routers/Login";
 import ValidationRouter from "@/routers/Validation";
 import RenewalRouter from "@/routers/Renewal";
+import OTPRouter from "@/routers/OneTimePassword";
 
 const app = express();
 
@@ -13,5 +14,6 @@ app.use(cookieParser());
 app.use("/api/auth/login", LoginRouter);
 app.use("/api/auth/validate", ValidationRouter);
 app.use("/api/auth/renew", RenewalRouter);
+app.use("/api/totp/setup", OTPRouter);
 
 export default app;

--- a/src/express.ts
+++ b/src/express.ts
@@ -14,6 +14,6 @@ app.use(cookieParser());
 app.use("/api/auth/login", LoginRouter);
 app.use("/api/auth/validate", ValidationRouter);
 app.use("/api/auth/renew", RenewalRouter);
-app.use("/api/totp/setup", OTPRouter);
+app.use("/api/auth/totp/setup", OTPRouter);
 
 export default app;

--- a/src/models/realms/RealmFactory.ts
+++ b/src/models/realms/RealmFactory.ts
@@ -5,7 +5,7 @@ import DotbaseRealmModel from "@/models/realms/DotbaseRealm";
 export default abstract class RealmFactory {
   public static realms = [PatientRealmModel.instance, DotbaseRealmModel.instance];
 
-  public static realm(realmName: string): realmConfig {
+  public static realm(realmName: string | undefined): realmConfig {
     switch (realmName) {
       case process.env.KEYCLOAK_DOTBASE_REALM_NAME:
         return DotbaseRealmModel.instance;

--- a/src/routers/OneTimePassword.ts
+++ b/src/routers/OneTimePassword.ts
@@ -1,20 +1,15 @@
 import express from "express";
-import CookieService from "@/services/Cookie";
 import OTPService from "@/services/OneTimePassword";
-
 
 const router: express.Router = express.Router();
 
-router.use("/", async (req, res) => {
+router.use("/:patientId", async (req, res) => {
   try {
     if (!req.cookies.session) throw new Error("Request is missing a session cookie.");
 
-    await CookieService.validateSessionCookie(req.cookies.session);
-    //TODO: retrieve patientId
-    const patientId = "";
-    await OTPService.getQrCode(patientId);
+    const qrCode = await OTPService.getQrCode(req.params.patientId, req.cookies.session);
 
-    res.status(200).send();
+    res.status(200).send(qrCode);
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
   } catch (e: any) {

--- a/src/routers/OneTimePassword.ts
+++ b/src/routers/OneTimePassword.ts
@@ -1,6 +1,5 @@
 import express from "express";
 import OTPService from "@/services/OneTimePassword";
-import RealmFactory from "@/models/realms/RealmFactory";
 
 const router: express.Router = express.Router();
 

--- a/src/routers/OneTimePassword.ts
+++ b/src/routers/OneTimePassword.ts
@@ -1,5 +1,6 @@
 import express from "express";
 import OTPService from "@/services/OneTimePassword";
+import RealmFactory from "@/models/realms/RealmFactory";
 
 const router: express.Router = express.Router();
 
@@ -7,11 +8,9 @@ router.use("/:patientId", async (req, res) => {
   try {
     if (!req.cookies.session) throw new Error("Request is missing a session cookie.");
 
-    const realmName = await OTPService.getAuthorizedRealmName(req.cookies.session);
-    const qrCode = await OTPService.getQrCode(req.params.patientId);
+    const qrCode = await OTPService.getQrCode(req.cookies.session, req.params.patientId);
 
-    res.setHeader("X-Auth-Realm", realmName);
-    res.status(200).send(qrCode);
+    res.status(200).send({ qrCode: qrCode });
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
   } catch (e: any) {

--- a/src/routers/OneTimePassword.ts
+++ b/src/routers/OneTimePassword.ts
@@ -1,0 +1,26 @@
+import express from "express";
+import CookieService from "@/services/Cookie";
+import OTPService from "@/services/OneTimePassword";
+
+
+const router: express.Router = express.Router();
+
+router.use("/", async (req, res) => {
+  try {
+    if (!req.cookies.session) throw new Error("Request is missing a session cookie.");
+
+    await CookieService.validateSessionCookie(req.cookies.session);
+    //TODO: retrieve patientId
+    const patientId = "";
+    await OTPService.getQrCode(patientId);
+
+    res.status(200).send();
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  } catch (e: any) {
+    res.status(403).send(e.message);
+    return;
+  }
+});
+
+export default router;

--- a/src/routers/OneTimePassword.ts
+++ b/src/routers/OneTimePassword.ts
@@ -7,8 +7,10 @@ router.use("/:patientId", async (req, res) => {
   try {
     if (!req.cookies.session) throw new Error("Request is missing a session cookie.");
 
-    const qrCode = await OTPService.getQrCode(req.params.patientId, req.cookies.session);
+    const realmName = await OTPService.getAuthorizedRealmName(req.cookies.session);
+    const qrCode = await OTPService.getQrCode(req.params.patientId);
 
+    res.setHeader("X-Auth-Realm", realmName);
     res.status(200).send(qrCode);
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/src/services/OneTimePassword.ts
+++ b/src/services/OneTimePassword.ts
@@ -1,5 +1,5 @@
 import KeycloakApi from "@/api/keycloak";
-import CookieService from "./Cookie";
+import CookieService from "@/services/Cookie";
 
 export default class OneTimePassword {
   public static async getQrCode(patientId: string): Promise<string> {

--- a/src/services/OneTimePassword.ts
+++ b/src/services/OneTimePassword.ts
@@ -1,0 +1,6 @@
+export default class OneTimePassword {
+  public static async getQrCode(patientId: string): Promise<string> {
+    const qrCode = await KeycloakApi.setupTOTP(patientId);
+    return qrCode;
+  }
+}

--- a/src/services/OneTimePassword.ts
+++ b/src/services/OneTimePassword.ts
@@ -2,13 +2,17 @@ import KeycloakApi from "@/api/keycloak";
 import CookieService from "./Cookie";
 
 export default class OneTimePassword {
-  public static async getQrCode(patientId: string, sessionCookie: string): Promise<string> {
+  public static async getQrCode(patientId: string): Promise<string> {
+    const qrCode = await KeycloakApi.setupTOTP(patientId);
+    return qrCode;
+  }
+
+  public static async getAuthorizedRealmName(sessionCookie: string): Promise<string> {
     const realmName = await CookieService.validateSessionCookie(sessionCookie);
 
     const isAllowed = realmName === process.env.KEYCLOAK_DOTBASE_REALM_NAME;
     if (!isAllowed) throw new Error("User not authorized to setup OTP.");
 
-    const qrCode = await KeycloakApi.setupTOTP(patientId);
-    return qrCode;
+    return realmName;
   }
 }

--- a/src/services/OneTimePassword.ts
+++ b/src/services/OneTimePassword.ts
@@ -1,5 +1,13 @@
+import KeycloakApi from "@/api/keycloak";
+import CookieService from "./Cookie";
+
 export default class OneTimePassword {
-  public static async getQrCode(patientId: string): Promise<string> {
+  public static async getQrCode(patientId: string, sessionCookie: string): Promise<string> {
+    const realmName = await CookieService.validateSessionCookie(sessionCookie);
+
+    const isAllowed = realmName === process.env.KEYCLOAK_DOTBASE_REALM_NAME;
+    if (!isAllowed) throw new Error("User not authorized to setup OTP.");
+
     const qrCode = await KeycloakApi.setupTOTP(patientId);
     return qrCode;
   }

--- a/src/services/OneTimePassword.ts
+++ b/src/services/OneTimePassword.ts
@@ -1,18 +1,19 @@
 import KeycloakApi from "@/api/keycloak";
+import RealmFactory from "@/models/realms/RealmFactory";
 import CookieService from "@/services/Cookie";
 
 export default class OneTimePassword {
-  public static async getQrCode(patientId: string): Promise<string> {
-    const qrCode = await KeycloakApi.setupTOTP(patientId);
+  public static async getQrCode(sessionCookie: string, patientId: string): Promise<string> {
+    await this.validateAuthorization(sessionCookie);
+    const realm = RealmFactory.realm(process.env.KEYCLOAK_PATIENT_REALM_NAME);
+    const qrCode = await KeycloakApi.setupTOTP(realm, patientId);
     return qrCode;
   }
 
-  public static async getAuthorizedRealmName(sessionCookie: string): Promise<string> {
-    const realmName = await CookieService.validateSessionCookie(sessionCookie);
+  public static async validateAuthorization(sessionCookie: string): Promise<void> {
+    const realm = await CookieService.validateSessionCookie(sessionCookie);
 
-    const isAllowed = realmName === process.env.KEYCLOAK_DOTBASE_REALM_NAME;
-    if (!isAllowed) throw new Error("User not authorized to setup OTP.");
-
-    return realmName;
+    const isDotbaseUser = realm.realmName === process.env.KEYCLOAK_DOTBASE_REALM_NAME;
+    if (!isDotbaseUser) throw new Error("User not authorized to setup OTP.");
   }
 }

--- a/tests/Login.test.ts
+++ b/tests/Login.test.ts
@@ -9,7 +9,6 @@ jest.mock("@/services/Cookie");
 
 @Describe("Login endpoint")
 export default class LoginTestGroup {
-
   @Test(
     "should respond with HTTP status 200 and a session cookie if valid login credentials are submitted"
   )

--- a/tests/Renewal.test.ts
+++ b/tests/Renewal.test.ts
@@ -9,7 +9,6 @@ jest.mock("@/services/Cookie");
 
 @Describe("Renewal endpoint")
 export default class RenewalTestGroup {
-
   @Test(
     "should respond with HTTP status 200 and a session cookie if a valid session cookie is submitted"
   )


### PR DESCRIPTION
This introduces a new endpoint `<gateway>/api/auth/totp/setup/<patientId>` to retrieve a base64 encoded qr-code. This closes #8.