### PR TITLE
feat: add endpoint to retrieve userinfo from token

### DIFF
--- a/src/express.ts
+++ b/src/express.ts
@@ -5,6 +5,8 @@ import LoginRouter from "@/routers/Login";
 import ValidationRouter from "@/routers/Validation";
 import RenewalRouter from "@/routers/Renewal";
 import OTPRouter from "@/routers/OneTimePassword";
+import UserInfoRouter from "@/routers/UserInfo";
+
 
 const app = express();
 
@@ -14,6 +16,7 @@ app.use(cookieParser());
 app.use("/api/auth/login", LoginRouter);
 app.use("/api/auth/validate", ValidationRouter);
 app.use("/api/auth/renew", RenewalRouter);
+app.use("/api/auth/userinfo", UserInfoRouter);
 app.use("/api/auth/totp/setup", OTPRouter);
 
 export default app;

--- a/src/express.ts
+++ b/src/express.ts
@@ -7,7 +7,6 @@ import RenewalRouter from "@/routers/Renewal";
 import OTPRouter from "@/routers/OneTimePassword";
 import UserInfoRouter from "@/routers/UserInfo";
 
-
 const app = express();
 
 app.use(express.json());

--- a/src/routers/UserInfo.ts
+++ b/src/routers/UserInfo.ts
@@ -1,0 +1,22 @@
+import express from "express";
+import CookieService from "@/services/Cookie";
+
+const router: express.Router = express.Router();
+
+router.use("/", async (req, res) => {
+  try {
+    if (!req.cookies.session) throw new Error("Request is missing a session cookie.");
+
+    const realmName = await CookieService.validateSessionCookie(req.cookies.session);
+
+    res.setHeader("X-Auth-Realm", realmName);
+    res.status(200).send();
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  } catch (e: any) {
+    res.status(403).send(e.message);
+    return;
+  }
+});
+
+export default router;

--- a/src/routers/UserInfo.ts
+++ b/src/routers/UserInfo.ts
@@ -7,10 +7,9 @@ router.use("/", async (req, res) => {
   try {
     if (!req.cookies.session) throw new Error("Request is missing a session cookie.");
 
-    const realmName = await CookieService.validateSessionCookie(req.cookies.session);
+    const userinfo = await CookieService.getUserInfo(req.cookies.session);
 
-    res.setHeader("X-Auth-Realm", realmName);
-    res.status(200).send();
+    res.status(200).send(userinfo);
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
   } catch (e: any) {

--- a/src/services/Cookie.ts
+++ b/src/services/Cookie.ts
@@ -34,4 +34,9 @@ export default class CookieService {
     }
     throw new Error("Access token is invalid.");
   }
+
+  public static async getUserInfo(sessionCookie: string): Promise<string> {
+    const tokens = CryptoService.decrypt(sessionCookie);
+    return await JwtUtil.getUserName(tokens);
+  }
 }

--- a/src/services/Cookie.ts
+++ b/src/services/Cookie.ts
@@ -2,6 +2,7 @@ import KeycloakApi from "@/api/keycloak";
 import RealmFactory from "@/models/realms/RealmFactory";
 import CryptoService from "@/services/Crypto";
 import RealmConfig from "@/types/RealmConfig";
+import UserInfo from "@/types/UserInfo";
 import JwtUtil from "@/utils/Jwt";
 
 export default class CookieService {
@@ -35,8 +36,8 @@ export default class CookieService {
     throw new Error("Access token is invalid.");
   }
 
-  public static async getUserInfo(sessionCookie: string): Promise<string> {
+  public static async getUserInfo(sessionCookie: string): Promise<UserInfo> {
     const tokens = CryptoService.decrypt(sessionCookie);
-    return await JwtUtil.getUserName(tokens);
+    return JwtUtil.getUserInfo(tokens);
   }
 }

--- a/src/types/UserInfo.ts
+++ b/src/types/UserInfo.ts
@@ -5,4 +5,5 @@ export default interface UserInfo {
   given_name: string;
   email: string;
   email_verified: boolean;
+  realm_access_roles: string[];
 }

--- a/src/types/UserInfo.ts
+++ b/src/types/UserInfo.ts
@@ -1,0 +1,8 @@
+export default interface UserInfo {
+  preferred_username: string;
+  name: string;
+  family_name: string;
+  given_name: string;
+  email: string;
+  email_verified: boolean;
+}

--- a/src/utils/Jwt.ts
+++ b/src/utils/Jwt.ts
@@ -1,4 +1,5 @@
 import Tokens from "@/types/Tokens";
+import UserInfo from "@/types/UserInfo";
 import jwt, { JwtPayload } from "jsonwebtoken";
 
 export default class JwtUtil {
@@ -33,10 +34,23 @@ export default class JwtUtil {
     return realmName;
   }
 
-  public static async getUserName(tokens: Tokens): Promise<string> {
-    const jwtPayload = await JwtUtil.decode(tokens.access_token);
+  public static getUserName(tokens: Tokens): string {
+    const jwtPayload = JwtUtil.decode(tokens.access_token);
     const userInfo = jwtPayload.preferred_username;
     if (!userInfo) throw new Error("Access token is invalid.");
+    return userInfo;
+  }
+
+  public static getUserInfo(tokens: Tokens): UserInfo {
+    const jwtPayload = JwtUtil.decode(tokens.access_token);
+    const userInfo: UserInfo = {
+      preferred_username: jwtPayload.preferred_username,
+      name: jwtPayload.name,
+      given_name: jwtPayload.given_name,
+      family_name: jwtPayload.family_name,
+      email: jwtPayload.email,
+      email_verified: jwtPayload.email_verified,
+    };
     return userInfo;
   }
 }

--- a/src/utils/Jwt.ts
+++ b/src/utils/Jwt.ts
@@ -50,6 +50,7 @@ export default class JwtUtil {
       family_name: jwtPayload.family_name,
       email: jwtPayload.email,
       email_verified: jwtPayload.email_verified,
+      realm_access_roles: jwtPayload.realm_access.roles,
     };
     return userInfo;
   }

--- a/src/utils/Jwt.ts
+++ b/src/utils/Jwt.ts
@@ -32,4 +32,11 @@ export default class JwtUtil {
     if (!realmName) throw new Error("Access token is invalid.");
     return realmName;
   }
+
+  public static async getUserName(tokens: Tokens): Promise<string> {
+    const jwtPayload = await JwtUtil.decode(tokens.access_token);
+    const userInfo = jwtPayload.preferred_username;
+    if (!userInfo) throw new Error("Access token is invalid.");
+    return userInfo;
+  }
 }

--- a/src/utils/Jwt.ts
+++ b/src/utils/Jwt.ts
@@ -34,13 +34,6 @@ export default class JwtUtil {
     return realmName;
   }
 
-  public static getUserName(tokens: Tokens): string {
-    const jwtPayload = JwtUtil.decode(tokens.access_token);
-    const userInfo = jwtPayload.preferred_username;
-    if (!userInfo) throw new Error("Access token is invalid.");
-    return userInfo;
-  }
-
   public static getUserInfo(tokens: Tokens): UserInfo {
     const jwtPayload = JwtUtil.decode(tokens.access_token);
     const userInfo: UserInfo = {


### PR DESCRIPTION
This introduces a new endpoint `<gateway>/api/auth/userinfo` to return the requesting user's access token userinfo. This closes #9.