### PR TITLE
fix: remove tests directory from production build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ COPY . .
 RUN npm install && \
     npm run build && \
     mkdir ./builder && \
-    mv ./build ./builder/build && \
+    mv ./build/src ./builder/build && \
     mv ./tsconfig.json ./builder/tsconfig.json && \
     mv ./package.json ./builder/package.json
 


### PR DESCRIPTION
Since the tests are included in the tsconfig.json they create another top level directory in a tsc build. This broke the production running scripts since they assumed a path without this top level directory. This PR corrects the Dockerfile which will only copy the resulting src directory afterward.