### PR TITLE
fix: location header hostname

### DIFF
--- a/src/routers/Validation.ts
+++ b/src/routers/Validation.ts
@@ -12,12 +12,16 @@ router.use("/", async (req, res) => {
     const isExpired = await CookieService.validateCookieExpiration(req.cookies.session);
 
     if (isExpired) {
-      if (!req.headers["x-forwarded-uri"]) throw new Error("Request is missing a x-forwarded-uri header.");
-
       const sessionCookie = await CookieService.renewSessionCookie(req.cookies.session);
-
       res.cookie("session", sessionCookie.value, sessionCookie.options);
-      res.setHeader("Location", req.headers["x-forwarded-uri"]);
+
+      const host = req.headers["x-forwarded-host"];
+      const protocol = req.headers["x-forwarded-proto"];
+      const uri = req.headers["x-forwarded-uri"];
+      if (typeof host !== "string" || typeof protocol !== "string" || typeof uri !== "string")
+        throw new Error("Forwarded URI is invalid.");
+      res.setHeader("Location", new URL(uri, `${protocol}://${host}`).toString());
+
       res.status(307).send();
     }
 

--- a/tests/dotbase/Validation.test.ts
+++ b/tests/dotbase/Validation.test.ts
@@ -30,12 +30,17 @@ export default class ValidationTestGroup {
       .set("Accept", "application/json");
 
     const cookie = loginResponse.headers["set-cookie"][0];
-    const redirectUri = "http://movebase.charite.de/anywhere";
+    const redirectProtocol = "http";
+    const redirectHost = "dotbase.example.org";
+    const redirectPath = "/anywhere";
+    const redirectUri = `${redirectProtocol}://${redirectHost}${redirectPath}`;
 
     await request(express)
       .get("/api/auth/validate")
       .set("Cookie", cookie)
-      .set("x-forwarded-uri", redirectUri)
+      .set("x-forwarded-proto", redirectProtocol)
+      .set("x-forwarded-host", redirectHost)
+      .set("x-forwarded-uri", redirectPath)
       .expect(307)
       .expect("set-cookie", /.*session=.*/)
       .expect("location", redirectUri);

--- a/tests/patients/Validation.test.ts
+++ b/tests/patients/Validation.test.ts
@@ -17,12 +17,17 @@ export default class ValidationTestGroup {
       .set("Accept", "application/json");
 
     const cookie = loginResponse.headers["set-cookie"][0];
-    const redirectUri = "http://movebase.charite.de/anywhere";
+    const redirectProtocol = "http";
+    const redirectHost = "dotbase.example.org";
+    const redirectPath = "/anywhere";
+    const redirectUri = `${redirectProtocol}://${redirectHost}${redirectPath}`;
 
     await request(express)
       .get("/api/auth/validate")
       .set("Cookie", cookie)
-      .set("x-forwarded-uri", redirectUri)
+      .set("x-forwarded-proto", redirectProtocol)
+      .set("x-forwarded-host", redirectHost)
+      .set("x-forwarded-uri", redirectPath)
       .expect(307)
       .expect("set-cookie", /.*session=.*/)
       .expect("location", redirectUri);


### PR DESCRIPTION
This fixes the location header hostname. X-Forwarded-Uri only provides the path, not the hostname or protocol of the forwarded request.