### PR TITLE
feat: restrict userinfo endpoint for patients

### DIFF
--- a/src/routers/UserInfo.ts
+++ b/src/routers/UserInfo.ts
@@ -8,6 +8,8 @@ router.get("/", async (req, res) => {
   try {
     if (!req.cookies.session) throw new HTTPError("Request is missing a session cookie.", 401);
 
+    if(req.headers["x-auth-realm"] !== process.env.KEYCLOAK_DOTBASE_REALM_NAME) throw new HTTPError("The user is not authorized to request userinfo", 403);
+
     const userinfo = await CookieService.getUserInfo(req.cookies.session);
 
     res.status(200).send(userinfo);

--- a/tests/dotbase/UserInfo.test.ts
+++ b/tests/dotbase/UserInfo.test.ts
@@ -18,7 +18,7 @@ export default class UserInfoTestGroup {
 
     const cookie = loginResponse.headers["set-cookie"][0];
 
-    const res = await request(express).get("/api/auth/userinfo").set("Cookie", cookie).expect(200);
+    const res = await request(express).get("/api/auth/userinfo").set("x-auth-realm", process.env.KEYCLOAK_DOTBASE_REALM_NAME ?? "dotbase").set("Cookie", cookie).expect(200);
     expect(res.body).toHaveProperty("preferred_username");
   }
 
@@ -26,6 +26,7 @@ export default class UserInfoTestGroup {
   private async testUserInfoInvalidSessionCookie() {
     await request(express)
       .get("/api/auth/userinfo")
+      .set("x-auth-realm", process.env.KEYCLOAK_DOTBASE_REALM_NAME ?? "dotbase")
       .set("Cookie", "session=some-invalid-cookie-value")
       .expect(401);
   }

--- a/tests/patients/UserInfo.test.ts
+++ b/tests/patients/UserInfo.test.ts
@@ -8,9 +8,9 @@ jest.mock("@/api/Keycloak");
 @Describe("UserInfo endpoint for a patient user")
 export default class UserInfoTestGroup {
   @Test(
-    "should respond with HTTP status 200 and a userinfo json if a valid session cookie is submitted"
+    "should respond with HTTP status 403"
   )
-  private async testUserInfoValidSessionCookie() {
+  private async testUserInfoForbidden() {
     const loginResponse = await request(express)
       .post("/api/auth/login/patients")
       .send({ username: "test", password: "test" })
@@ -18,7 +18,6 @@ export default class UserInfoTestGroup {
 
     const cookie = loginResponse.headers["set-cookie"][0];
 
-    const res = await request(express).get("/api/auth/userinfo").set("Cookie", cookie).expect(200);
-    expect(res.body).toHaveProperty("preferred_username");
+    await request(express).get("/api/auth/userinfo").set("x-auth-realm", process.env.KEYCLOAK_PATIENT_REALM_NAME ?? "patients").set("Cookie", cookie).expect(403);
   }
 }


### PR DESCRIPTION
This PR restricts the endpoint /userinfo for users registered at dotbase realm only.